### PR TITLE
Add Auto Roll d20 instead of just the prompt option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,15 @@ This module adds a Chat message every time a player with the feat `Wild Magic Su
 
 I was getting fed up of having to remember whenever this occured so I created this small module to alert me.
 
-You have an option to change the default message in the module settings page should you wish.
+You have an option to change the default message in the module settings page should you wish among other options. See the configure section below for more details.
+
+## Configure
+
+This module gives you two ways of playing. 
+
+1. (Default) The first option is to show a prompt every time a player uses a 1st level or higher spell in the chat window.
+
+2. The additional option `Auto Roll d20 instead of just the prompt` will auto roll in the background for you and upon a `1` will show a prompt that a Wild Magic Surge has occured and that they should roll a d100. This message is configurable should you wish.
 
 ## Installation
 

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -3,19 +3,42 @@ const MODULE_ID = "wild-magic-surge-5e";
 
 const OPT_ENABLE_CHECK = "enableMagicSurgeCheck";
 const OPT_CHAT_MSG = "magicSurgeChatMessage";
+const OPT_AUTO_D20 = "autoRollD20";
+const OPT_AUTO_D20_MSG = "autoRollD20Message";
 
 function hasWildMagicFeat(data) {
-    return data._actor.data.items.find(
-        (a) => a.name === `Wild Magic Surge` && a.type === "feat"
-      ) !== undefined;
+  return (
+    data._actor.data.items.find(
+      (a) => a.name === `Wild Magic Surge` && a.type === "feat"
+    ) !== undefined
+  );
 }
 
 function is1stLevelOrHigherSpell(data) {
-    return data._item.labels.level.indexOf(" Level") > -1;
+  return data._item.labels.level.indexOf(" Level") > -1;
+}
+
+function actorName(data) {
+  return data._actor.data.name;
 }
 
 function isValid(data) {
-    return (hasWildMagicFeat(data) && is1stLevelOrHigherSpell(data))
+  return hasWildMagicFeat(data) && is1stLevelOrHigherSpell(data);
+}
+
+function sendChat(chatMessage) {
+  let chatData = {
+    user: game.user.id,
+    speaker: game.user,
+    content: `<div>${chatMessage.toString()}</div>`,
+  };
+  ChatMessage.create(chatData, {});
+}
+
+function wildMagicSurgeRollCheck() {
+  let r = new Roll("1d20");
+  r.evaluate();
+  return r.total;
 }
 
 Hooks.on("init", function () {
@@ -39,6 +62,24 @@ Hooks.on("init", function () {
     default: "Wild Magic Check - Roll a D20",
     type: String,
   });
+
+  game.settings.register(`${MODULE_ID}`, `${OPT_AUTO_D20}`, {
+    name: "Auto Roll d20 instead of just the prompt",
+    hint: "Auto roll a d20 and show the result.",
+    scope: "world",
+    config: true,
+    default: false,
+    type: Boolean,
+  });
+
+  game.settings.register(`${MODULE_ID}`, `${OPT_AUTO_D20_MSG}`, {
+    name: "Text to show in chat with Auto d20 roll.",
+    hint: "On a roll of 1 using the auto roll d20 feature, show this message.",
+    scope: "world",
+    config: true,
+    default: "Wild Magic Surge! Roll a D100!",
+    type: String,
+  });
 });
 
 Hooks.on("ready", function () {
@@ -49,12 +90,14 @@ Hooks.on("preRollItemBetterRolls", function (arg1, arg2, arg3) {
   try {
     if (game.settings.get(`${MODULE_ID}`, `${OPT_ENABLE_CHECK}`)) {
       if (isValid(arg1)) {
-        let chatData = {
-          user: game.user.id,
-          speaker: game.user,
-          content: game.settings.get(`${MODULE_ID}`, `${OPT_CHAT_MSG}`),
-        };
-        ChatMessage.create(chatData, {});
+        if (game.settings.get(`${MODULE_ID}`, `${OPT_AUTO_D20}`)) {
+          const result = wildMagicSurgeRollCheck();
+          if (result === 1) {
+            sendChat(game.settings.get(`${MODULE_ID}`, `${OPT_AUTO_D20_MSG}`));
+          }
+        } else {
+          sendChat(game.settings.get(`${MODULE_ID}`, `${OPT_CHAT_MSG}`));
+        }
       }
     }
   } catch (e) {


### PR DESCRIPTION
Adds the `Auto Roll d20 instead of just the prompt` option to silently roll each time a spell is cast. This will only prompt you if a `1` is rolled giving you a more less intrusive option.