### PR TITLE
Checks that the user who cast is the one who should role bug

### DIFF
--- a/scripts/MagicSurgeCheck.js
+++ b/scripts/MagicSurgeCheck.js
@@ -44,6 +44,10 @@ function isValid(chatMessage) {
     return false;
   }
 
+  if (chatMessage.data.user !== game.user.id) {
+    return false;
+  }
+
   const isASpell = parseSpell(chatMessage.data.content);
   const actor = game.actors.get(chatMessage.data.speaker.actor);
   if (actor === null) {


### PR DESCRIPTION
There was a bug where every player would role instead of just the caster who cast the spell.

This change checks the id of the user who cast against the logged in user id and only roles if they match.

Fixes #14