### PR TITLE
Version check fix for FoundryVTT browser compatiblity

### DIFF
--- a/scripts/RollTableMagicSurge.js
+++ b/scripts/RollTableMagicSurge.js
@@ -18,7 +18,7 @@ export async function RollTableMagicSurge() {
   );
 
   // TODO: Remove in final v0.8 release
-  if (parseInt(game.data.version.replaceAll(".", "")) > 80) {
+  if (parseInt(game.data.version.replace(/./g, '')) > 80) {
     surgeRollTable.roll().then((result) => {
       SendRollTable(result, surgeRollTable);
     });


### PR DESCRIPTION
The built-in FoundryVTT browser (version 0.7.9) throws an error when attempting to evaluate <string>.replaceAll(), claiming the function is undefined, which prevents the automatic d100 roll. I've changed this to a call to 'replace'  using a regex with the global flag to achieve the same effect, which has more widespread browser compatibility.

Great module, I had just sat down to write a Wild Magic module since one of my players subclassed last session, and decided I had better check to see if someone had beat me to it. 

