### PR TITLE
Fix when token placeable exists with no actor

### DIFF
--- a/scripts/module.ts
+++ b/scripts/module.ts
@@ -21,7 +21,7 @@ Hooks.on("init", function () {
 });
 
 function getTokenIdByActorId(actorId: string) {
-  return canvas.tokens.placeables.find((f) => f.actor.id === actorId)?.id;
+  return canvas.tokens?.placeables?.find((f) => f.actor?.id === actorId)?.id;
 }
 
 Hooks.once("ready", async function () {


### PR DESCRIPTION
# Description

Fix when token placeable exists with no actor on canvas. This can occur when a scene has a token that had a token assigned to an actor and the actor no longer exists.

When using `find` on placeables it throws a null exception error.