### PR TITLE
Auto roll table to whisper gm to its own setting

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -13,8 +13,11 @@
 
   "WildMagicSurge5E.opt_incremental_check_to_chat_text_name": "Wild Magic Surge Charge Count",
 
-  "WildMagicSurge5E.opt_whisper_gm_name": "Whisper chat results to GM",
-  "WildMagicSurge5E.opt_whisper_gm_hint": "When enabled, all messages are sent as Blind GM messages instead of from the player.",
+  "WildMagicSurge5E.opt_whisper_gm_name": "Whisper Wild Magic Surge Roll Check to GM",
+  "WildMagicSurge5E.opt_whisper_gm_hint": "The surge check roll message is only sent to the GM instead of all players.",
+  
+  "WildMagicSurge5E.opt_whisper_gm_roll_chat_name": "Whisper Auto Roll Table result to GM",
+  "WildMagicSurge5E.opt_whisper_gm_roll_chat_hint": "Auto Roll Table results are only sent to the GM instead of all players.",
 
   "WildMagicSurge5E.opt_chat_msg_name": "Message to check for surge",
   "WildMagicSurge5E.opt_chat_msg_hint": "When automation is disabled, this message will show in chat to remind you when a spell is cast.",

--- a/scripts/Chat.test.ts
+++ b/scripts/Chat.test.ts
@@ -58,6 +58,7 @@ describe("Chat", () => {
         (global as any).game.settings.get = jest
           .fn()
           .mockResolvedValueOnce(false)
+          .mockResolvedValueOnce(false)
           .mockResolvedValueOnce("Wild Magic Surge")
           .mockResolvedValueOnce("rollMode");
         roll = {
@@ -143,6 +144,47 @@ describe("Chat", () => {
       });
     });
 
+    describe("Given I set whisper gm for roll table", () => {
+      let rollResult: any;
+      let surgeRollTable: any;
+
+      beforeEach(() => {
+        (global as any).game.settings.get = jest
+          .fn()
+          .mockResolvedValueOnce(false)
+          .mockResolvedValueOnce(true)
+          .mockResolvedValueOnce("Wild Magic Surge")
+          .mockResolvedValueOnce("rollMode");
+        surgeRollTable = {
+          data: {
+            description: "Wild Magic Surge Table",
+          },
+        };
+        rollResult = {
+          results: [
+            {
+              text: "test text",
+
+              getChatText: jest.fn(),
+            },
+          ],
+          roll: {
+            result: 20,
+
+            render: jest.fn().mockResolvedValue(null),
+          },
+        };
+      });
+
+      it("It returns the just the content", async () => {
+        await Chat.Send(WMSCONST.CHAT_TYPE.TABLE, "", rollResult, surgeRollTable);
+
+        expect(ChatMessage.create).toHaveBeenCalled();
+
+        expect(global.renderTemplate).toHaveBeenCalled();
+      });
+    });
+
     describe("Given I pass it a message and roll table with one result", () => {
       let rollResult: any;
       let surgeRollTable: any;
@@ -150,6 +192,7 @@ describe("Chat", () => {
       beforeEach(() => {
         (global as any).game.settings.get = jest
           .fn()
+          .mockResolvedValueOnce(false)
           .mockResolvedValueOnce(false)
           .mockResolvedValueOnce("Wild Magic Surge")
           .mockResolvedValueOnce("rollMode");
@@ -190,6 +233,7 @@ describe("Chat", () => {
       beforeEach(() => {
         (global as any).game.settings.get = jest
           .fn()
+          .mockResolvedValueOnce(false)
           .mockResolvedValueOnce(false)
           .mockResolvedValueOnce("Wild Magic Surge")
           .mockResolvedValueOnce("rollMode");

--- a/scripts/ModuleSettings.ts
+++ b/scripts/ModuleSettings.ts
@@ -107,6 +107,23 @@ class ModuleSettings {
 
     game.settings.register(
       `${WMSCONST.MODULE_ID}`,
+      `${WMSCONST.OPT_WHISPER_GM_ROLL_CHAT}`,
+      {
+        name: game.i18n.format(
+          "WildMagicSurge5E.opt_whisper_gm_roll_chat_name"
+        ),
+        hint: game.i18n.format(
+          "WildMagicSurge5E.opt_whisper_gm_roll_chat_hint"
+        ),
+        scope: "world",
+        config: true,
+        default: false,
+        type: Boolean,
+      }
+    );
+
+    game.settings.register(
+      `${WMSCONST.MODULE_ID}`,
       `${WMSCONST.OPT_SURGE_TYPE}`,
       {
         name: game.i18n.format("WildMagicSurge5E.opt_surge_type_name"),

--- a/scripts/WMSCONST.ts
+++ b/scripts/WMSCONST.ts
@@ -6,6 +6,7 @@ export const WMSCONST = {
   OPT_POWM_NAME: "powmName",
 
   OPT_WHISPER_GM: "whisperToGM",
+  OPT_WHISPER_GM_ROLL_CHAT: "whisperToGMRollChat",
 
   OPT_TRIGGERMACRO_ENABLE: "enableTriggerMacro",
   OPT_TRIGGERMACRO_NAME: "triggerMacroName",

--- a/scripts/utils/SurgeDetails.test.ts
+++ b/scripts/utils/SurgeDetails.test.ts
@@ -134,9 +134,8 @@ describe("SurgeDetails", () => {
           settings: {
             get: jest
               .fn()
-              .mockReturnValueOnce(true)
               .mockReturnValueOnce(false)
-              .mockReturnValueOnce(false),
+              .mockReturnValueOnce(true),
           },
         };
 

--- a/scripts/utils/SurgeDetails.ts
+++ b/scripts/utils/SurgeDetails.ts
@@ -5,8 +5,6 @@ export default class SurgeDetails {
   _actor: Actor;
   _item: Item;
   _userId?: string;
-  _isWhisperToGM = false;
-  _whisperToGM: boolean;
   _hasPathOfWildMagicFeat: boolean;
   _raging: boolean;
   _isASpell: boolean;
@@ -21,11 +19,6 @@ export default class SurgeDetails {
     this._item = item;
 
     this._valid = false;
-
-    this._whisperToGM = game.settings.get(
-      `${WMSCONST.MODULE_ID}`,
-      `${WMSCONST.OPT_WHISPER_GM}`
-    );
 
     this._hasPathOfWildMagicFeat = SpellParser.IsPathOfWildMagicFeat(
       this._actor


### PR DESCRIPTION
# Description

Adds setting to choose whether to whisper to gm for Wild Magic Suge roll checks and Auto Roll table seperately.

e.g. Allow all players to see roll checks but only show the GM the roll table result.