### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/languages/es.json
+++ b/languages/es.json
@@ -1,1 +1,13 @@
-{}
+{
+	"WildMagicSurge5E.opt_toc_feat_name_name": "Nombre de la hazaña de Mareas del Caos",
+	"WildMagicSurge5E.opt_toc_feat_name_hint": "Si juegas en otro idioma, esto te permite establecer el nombre de la hazaña en tu idioma.",
+	"WildMagicSurge5E.opt_powm_feat_name_name": "Nombre de la hazaña de Camino de la Magia Salvaje",
+	"WildMagicSurge5E.opt_powm_feat_name_hint": "Si juegas en otro idioma, esto te permite establecer el nombre de la hazaña en tu idioma.",
+	"WildMagicSurge5E.opt_incremental_check_to_chat_name": "Enviar al chat",
+	"WildMagicSurge5E.opt_incremental_check_to_chat_text_name": "Recuento de Carga de Oleada de Magia Salvaje",
+	"WildMagicSurge5E.opt_whisper_gm_name": "Susurra el Control de Tirada de Oleada de Magia Salvaje al DJ",
+	"WildMagicSurge5E.opt_whisper_gm_hint": "El mensaje de tirada de verificación de aumento solo se envía al DJ en lugar de a todos los jugadores.",
+	"WildMagicSurge5E.opt_wms_feat_name_name": "Nombre de la hazaña de Oleada Mágica Salvaje",
+	"WildMagicSurge5E.opt_wms_feat_name_hint": "Si juegas en otro idioma, esto te permite establecer el nombre de la hazaña en tu idioma.",
+	"WildMagicSurge5E.opt_incremental_check_to_chat_hint": "Cuando está habilitado, cada vez que cambia un tipo de verificación incremental para un aumento, se publica en Chat para que otros lo vean."
+}

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -71,5 +71,7 @@
 	"WildMagicSurge5E.opt_show_wms_debug_option_name": "Afficher l'option Debug dans la feuille de personnage",
 	"WildMagicSurge5E.opt_show_wms_debug_option_hint": "Désactiver le bouton Debug WMS dans l'en-tête des feuilles de personnage. Cette option peut généralement être désactivée une fois que votre personnage est configuré et fonctionne. (Nécessite un rechargement).",
 	"WildMagicSurge5E.opt_whisper_gm_roll_chat_hint": "Les résultats de la table des jets automatiques ne sont envoyés qu'au MJ et non à tous les joueurs.",
-	"WildMagicSurge5E.opt_whisper_gm_roll_chat_name": "Chuchoter le résultat de la table des jets automatiques au MJ"
+	"WildMagicSurge5E.opt_whisper_gm_roll_chat_name": "Chuchoter le résultat de la table des jets automatiques au MJ",
+	"WildMagicSurge5E.opt_auto_d20_msg_enabled_name": "Afficher le message",
+	"WildMagicSurge5E.opt_auto_d20_msg_enabled_hint": "En option, vous pouvez activer l'affichage de ce message."
 }


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [Wild Magic Surge 5e/main](https://weblate.foundryvtt-hub.com/projects/wild-magic-surge-5e/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/wild-magic-surge-5e/-/main/horizontal-auto.svg)