### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/languages/de.json
+++ b/languages/de.json
@@ -1,1 +1,10 @@
-{}
+{
+	"WildMagicSurge5E.opt_wms_feat_name_name": "Name der Fähigkeit \"Wilde Magie\"",
+	"WildMagicSurge5E.opt_wms_feat_name_hint": "Wenn Sie in einer anderen Sprache spielen, können Sie den Namen des Merkmals auf Ihre Sprache einstellen.",
+	"WildMagicSurge5E.opt_toc_feat_name_hint": "Wenn Sie in einer anderen Sprache spielen, können Sie den Namen des Merkmals auf Ihre Sprache einstellen.",
+	"WildMagicSurge5E.opt_powm_feat_name_name": "Name of the Path of Wild Magic feat",
+	"WildMagicSurge5E.opt_powm_feat_name_hint": "Wenn Sie in einer anderen Sprache spielen, können Sie den Namen des Merkmals auf Ihre Sprache einstellen.",
+	"WildMagicSurge5E.opt_incremental_check_to_chat_name": "Zum Chatten senden",
+	"WildMagicSurge5E.opt_incremental_check_to_chat_hint": "Wenn diese Funktion aktiviert ist, wird jedes Mal, wenn sich die Art der inkrementellen Prüfung für einen Stromstoß ändert, im Chat gepostet, damit andere sie sehen können.",
+	"WildMagicSurge5E.opt_incremental_check_to_chat_text_name": "Anzahl der Aufladungen für wilde Zaubersprüche"
+}


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [Wild Magic Surge 5e/main](https://weblate.foundryvtt-hub.com/projects/wild-magic-surge-5e/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/wild-magic-surge-5e/-/main/horizontal-auto.svg)