### PR TITLE
Fix run macro on surge

### DIFF
--- a/scripts/MagicSurgeCheck.test.ts
+++ b/scripts/MagicSurgeCheck.test.ts
@@ -11,6 +11,7 @@ import { actor } from "../MockData/actor";
 import "../__mocks__/index";
 import AutoEffects from "./AutoEffects";
 import { firstLevel, melee } from "../MockData/items";
+import TriggerMacro from "./TriggerMacro";
 
 const mockSpellParserIsPathOfWildMagicFeat = jest.spyOn(
   SpellParser,
@@ -69,6 +70,9 @@ SpellLevelTrigger.Check = mockSpellLevelTriggerCheck;
 const mockAutoEffect = jest.fn();
 AutoEffects.Run = mockAutoEffect;
 
+const mockTriggerMacro = jest.fn();
+TriggerMacro.Run = mockTriggerMacro;
+
 (global as any).Hooks = {
   callAll: jest.fn().mockReturnValue(undefined),
 };
@@ -88,6 +92,7 @@ beforeEach(() => {
   mockSpellLevelTriggerCheck.mockClear();
   mockIncrementalCheckCheck.mockClear();
   mockAutoEffect.mockClear();
+  mockTriggerMacro.mockClear();
   mockSurgeDetailsValid.mockClear();
   mockSurgeDetailsHasPathOfWildMagicFeat.mockClear();
   mockSurgeDetailsSpellLevel.mockClear();

--- a/scripts/MagicSurgeCheck.ts
+++ b/scripts/MagicSurgeCheck.ts
@@ -9,6 +9,7 @@ import AutoEffects from "./AutoEffects";
 import CallHooks from "./utils/CallHooks";
 import SurgeDetails from "./utils/SurgeDetails";
 import Logger from "./Logger";
+import TriggerMacro from "./TriggerMacro";
 
 /**
  * Main entry point for Wild Magic Surge Checks
@@ -231,15 +232,9 @@ class MagicSurgeCheck {
       actorId: this._actor.id,
     });
 
-    game.socket?.emit("module.wild-magic-surge-5e", {
-      event: "IsWildMagicSurge",
-      data: {
-        surge: isSurge,
-        result: rollResult?.result,
-        tokenId: this._tokenId,
-        actorId: this._actor.id,
-      },
-    });
+    if (isSurge && this._actor.id) {
+      TriggerMacro.Run(this._actor.id, this._actor.id);
+    }
   }
 
   /**

--- a/scripts/module.ts
+++ b/scripts/module.ts
@@ -6,7 +6,6 @@ import ModuleSettings from "./ModuleSettings";
 import { ActorHelperPanel } from "./panels/ActorHelperPanel";
 import { RoundData } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/client/data/documents/combat";
 import Logger from "./Logger";
-import TriggerMacro from "./TriggerMacro";
 import Flags from "./utils/Flags";
 
 Hooks.on("init", function () {
@@ -36,9 +35,6 @@ Hooks.once("ready", async function () {
     game.socket?.on(
       "module.wild-magic-surge-5e",
       async function (payload: unknown) {
-        if (payload.event === "IsWildMagicSurge") {
-          TriggerMacro.Run(payload.data.actorId, payload.data.tokenId);
-        }
         if (payload.event === "SurgeCheck") {
           const surgeCheckData = payload.data;
           const actor = game.actors.get(surgeCheckData.actorId);


### PR DESCRIPTION
# Description

Fixes issue where new functionality to trigger surge from the player no longer triggers the run macro function.

## Bump type

Ensure the bump type is set in the PR title

- `#major`
- `#minor`
- `#patch` (default)
- `#none`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update