### PR TITLE
Add wild magic feat check when regex enabled

### DIFF
--- a/scripts/utils/SurgeDetails.test.ts
+++ b/scripts/utils/SurgeDetails.test.ts
@@ -3,6 +3,7 @@ import SpellParser from "./SpellParser";
 import { actor } from "../../MockData/actor";
 import "../../__mocks__/index";
 import { firstLevel } from "../../MockData/items";
+import { actorNoWildMagic } from "../../MockData/actorNoWildMagic";
 
 const mockSpellParserIsPathOfWildMagicFeat = jest.spyOn(
   SpellParser,
@@ -84,7 +85,7 @@ describe("SurgeDetails", () => {
         mockSpellParserIsPathOfWildMagicFeat.mockReturnValue(false);
       });
       it("should be undefined", () => {
-        const surgeChatMessageDetails = new SurgeDetails(actor, firstLevel);
+        const surgeChatMessageDetails = new SurgeDetails(actorNoWildMagic, firstLevel);
 
         expect(
           surgeChatMessageDetails.isSorcererSpellRegexMatch
@@ -95,7 +96,8 @@ describe("SurgeDetails", () => {
       beforeEach(() => {
         (global as any).game = {
           settings: {
-            get: jest.fn().mockReturnValue(true),
+            get: jest.fn().mockReturnValueOnce("Wild Magic Surge")
+            .mockReturnValue(true),
           },
         };
 

--- a/scripts/utils/SurgeDetails.ts
+++ b/scripts/utils/SurgeDetails.ts
@@ -56,15 +56,15 @@ export default class SurgeDetails {
       return this._raging;
     }
 
-    if (this.isSorcererSpellRegexMatch !== undefined) {
-      return (
-        this._isASpell &&
-        this.isSorcererSpellRegexMatch &&
-        this._hasWildMagicFeat
-      );
+    if (!this._hasWildMagicFeat) {
+      return false;
     }
 
-    let isValid = this._isASpell && this._hasWildMagicFeat;
+    if (this.isSorcererSpellRegexMatch !== undefined) {
+      return this._isASpell && this.isSorcererSpellRegexMatch;
+    }
+
+    let isValid = this._isASpell;
 
     if (
       !game.settings.get(`${WMSCONST.MODULE_ID}`, `${WMSCONST.OPT_ENABLE_NPCS}`)

--- a/scripts/utils/SurgeDetails.ts
+++ b/scripts/utils/SurgeDetails.ts
@@ -57,7 +57,11 @@ export default class SurgeDetails {
     }
 
     if (this.isSorcererSpellRegexMatch !== undefined) {
-      return this._isASpell && this.isSorcererSpellRegexMatch;
+      return (
+        this._isASpell &&
+        this.isSorcererSpellRegexMatch &&
+        this._hasWildMagicFeat
+      );
     }
 
     let isValid = this._isASpell && this._hasWildMagicFeat;


### PR DESCRIPTION
When Regex check is enabled, include a check for the wild magic feat. Without this any spell when inverse checked will trigger a surge check.

Fixes #446

