### PR TITLE
#minor Calculation Fix and small change for whispered DM message

### DIFF
--- a/scripts/Chat.ts
+++ b/scripts/Chat.ts
@@ -102,7 +102,7 @@ export default class Chat {
   ): Promise<ChatMessage> {
     if (isWhisperGM) {
       return <ChatMessage>{
-        content: `<div>${message} (${eval(roll.result)})</div>`,
+        content: `<div>${message} (${roll.result})</div>`,
       };
     } else {
       const wildMagicSurgeName = await game.settings.get(

--- a/scripts/Chat.ts
+++ b/scripts/Chat.ts
@@ -102,7 +102,7 @@ export default class Chat {
   ): Promise<ChatMessage> {
     if (isWhisperGM) {
       return <ChatMessage>{
-        content: `<div>${message} ${roll.result}</div>`,
+        content: `<div>${message} (${eval(roll.result)})</div>`,
       };
     } else {
       const wildMagicSurgeName = await game.settings.get(

--- a/scripts/Chat.ts
+++ b/scripts/Chat.ts
@@ -102,7 +102,7 @@ export default class Chat {
   ): Promise<ChatMessage> {
     if (isWhisperGM) {
       return <ChatMessage>{
-        content: `<div>${message} (${roll.result})</div>`,
+        content: `<div>${message} (${roll.total ?? 0})</div>`,
       };
     } else {
       const wildMagicSurgeName = await game.settings.get(

--- a/scripts/MagicSurgeCheck.ts
+++ b/scripts/MagicSurgeCheck.ts
@@ -193,7 +193,7 @@ class MagicSurgeCheck {
           const maxValue = gameType === `INCREMENTAL_CHECK_CHAOTIC` ? 10 : 20;
           isSurge = await IncrementalCheck.Check(
             this._actor,
-            eval(roll.result),
+            roll.total,
             maxValue
           );
           break;

--- a/scripts/MagicSurgeCheck.ts
+++ b/scripts/MagicSurgeCheck.ts
@@ -199,7 +199,7 @@ class MagicSurgeCheck {
           break;
         }
         case "SPELL_LEVEL_DEPENDENT_ROLL": {
-          isSurge = SpellLevelTrigger.Check(eval(roll.result), spellLevel);
+          isSurge = SpellLevelTrigger.Check(roll.total ?? 1, spellLevel);
           break;
         }
         case "DIE_DESCENDING": {

--- a/scripts/MagicSurgeCheck.ts
+++ b/scripts/MagicSurgeCheck.ts
@@ -193,13 +193,13 @@ class MagicSurgeCheck {
           const maxValue = gameType === `INCREMENTAL_CHECK_CHAOTIC` ? 10 : 20;
           isSurge = await IncrementalCheck.Check(
             this._actor,
-            parseInt(roll.result),
+            eval(roll.result),
             maxValue
           );
           break;
         }
         case "SPELL_LEVEL_DEPENDENT_ROLL": {
-          isSurge = SpellLevelTrigger.Check(parseInt(roll.result), spellLevel);
+          isSurge = SpellLevelTrigger.Check(eval(roll.result), spellLevel);
           break;
         }
         case "DIE_DESCENDING": {


### PR DESCRIPTION
# Description

The calculation for dice formulas was somewhat faulty, ignoring additions to the dice roll formulas such as 1d20 **+ 5**. This fix  now calculates the dice result with "eval" instead of "parseInt", adding a small amount of functionality while also fixing a niche bug.

In addition, added brackets to the whispered DM message to seperate the result from the surge/no surge text.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)