### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/languages/fr.json
+++ b/languages/fr.json
@@ -83,5 +83,7 @@
 	"WildMagicSurge5E.settings_panel_chat_message": "Options de messagerie",
 	"WildMagicSurge5E.configure": "Configurer",
 	"WildMagicSurge5E.settings_panel_information": "Informations sur la surcharge de la magie sauvage 5e",
-	"WildMagicSurge5E.es_roll_on_table": "Lancer une table"
+	"WildMagicSurge5E.es_roll_on_table": "Lancer une table",
+	"WildMagicSurge5E.opt_resource_type_name": "Définir la ressource à utiliser pour le suivi de type surcharge",
+	"WildMagicSurge5E.opt_resource_type_hint": "Choisissez la ressource sur la feuille de personnage de l'acteur à utiliser pour suivre les dés incrémentiels ou décroissants. Vous pouvez ensuite l'ajouter en tant que ressource à suivre sur votre jeton. Choisir Aucun, masque le suivi de l'acteur."
 }


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [Wild Magic Surge 5e/main](https://weblate.foundryvtt-hub.com/projects/wild-magic-surge-5e/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/wild-magic-surge-5e/-/main/horizontal-auto.svg)