### PR TITLE
Show as public roll instead of GM selection for table button

### DIFF
--- a/scripts/Chat.test.ts
+++ b/scripts/Chat.test.ts
@@ -60,6 +60,7 @@ describe("Chat", () => {
           .fn()
           .mockResolvedValueOnce(false)
           .mockResolvedValueOnce(false)
+          .mockResolvedValueOnce("PLAYER_TRIGGER")
           .mockResolvedValueOnce("Wild Magic Surge")
           .mockResolvedValueOnce("rollMode");
         roll = {

--- a/scripts/Chat.ts
+++ b/scripts/Chat.ts
@@ -42,7 +42,11 @@ export default class Chat {
         chatData = await this.createRollChat(
           message,
           rollObject,
-          isWhisperRollResultGM
+          isWhisperRollResultGM,
+          game.settings.get(
+            `${WMSCONST.MODULE_ID}`,
+            `${WMSCONST.OPT_ROLLTABLE_ENABLE}`
+          ) === "PLAYER_TRIGGER"
         );
         break;
       case WMSCONST.CHAT_TYPE.TABLE:
@@ -98,7 +102,8 @@ export default class Chat {
   static async createRollChat(
     message: string,
     roll: Roll,
-    isWhisperGM: boolean
+    isWhisperGM: boolean,
+    isRollOnTableButton = false
   ): Promise<ChatMessage> {
     if (isWhisperGM) {
       return <ChatMessage>{
@@ -113,7 +118,9 @@ export default class Chat {
         flavor: `${wildMagicSurgeName} Check - ${message}`,
         type: CONST.CHAT_MESSAGE_TYPES.ROLL,
         roll: roll,
-        rollMode: await game.settings.get("core", "rollMode"),
+        rollMode: isRollOnTableButton
+          ? "publicroll"
+          : await game.settings.get("core", "rollMode"),
       };
     }
   }


### PR DESCRIPTION
# Description

If roll on table button message is rendered, override to show as public roll instead of GM selection.

Logic now so if the GM has private or blind rolls selected the message will override this and show as public unless you specifically choose to whisper rolls in settings

Fixes #482 

## Bump type

Ensure the bump type is set in the PR title

- `#major`
- `#minor`
- `#patch` (default)
- `#none`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update