### PR TITLE
Add manual trigger hook for use in Macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This module provide various bits of functionality to help automate the `Wild Mag
   - [Send Incremental Check charge to chat](#send-incremental-check-charge-to-chat)
   - [Enable Auto Roll on a Wild Magic Surge Table](#enable-auto-roll-on-a-wild-magic-surge-table)
   - [Execute a GM Macro on a Wild Magic Surge](#execute-a-gm-macro-on-a-wild-magic-surge)
+  - [Trigger a Wild Magic Surge from your own Macro](#trigger-a-wild-magic-surge-from-your-own-macro)
   - [Tides of Chaos Recharge](#tides-of-chaos-recharge)
   - [Auto surge on spell use after Tides of Chaos has been used](#auto-surge-on-spell-use-after-tides-of-chaos-has-been-used)
   - [Dice Formula](#dice-formula)
@@ -160,6 +161,26 @@ When a surge happens you can specify your own macro to run. Note this will only 
 Included is a compendium containing examples and the javascript for them are in [/scripts/macros](scripts/macros/).
 
 [![Execute a GM Macro on a Wild Magic Surge](https://raw.githubusercontent.com/johnnolan/wild-magic-surge-5e/main/images/macro-surge.jpg)](https://raw.githubusercontent.com/johnnolan/wild-magic-surge-5e/main/images/macro-surge.jpg)
+
+### Trigger a Wild Magic Surge from your own Macro
+
+If you want to trigger a Wild Magic Surge from your own Macro, you can call the built in hook `wild-magic-surge-5e.manualTriggerWMS` and pass the actor with it.
+
+This feature will allow you to customise to your own preferences, what triggers the Wild Magic Surge.
+
+#### Example macro code
+
+- Select the token on the canvas you want to run the Wild Magic Surge for
+- Click your macro with the token still selected
+- The module will trigger a Wild Magic Surge on that actor
+
+``` js
+
+Hooks.callAll(`wild-magic-surge-5e.manualTriggerWMS`, actor);
+
+```
+
+Doing this will automatically trigger the Wild Magic Surge logic you have set up.
 
 ### Tides of Chaos Recharge
 

--- a/README.md
+++ b/README.md
@@ -172,11 +172,22 @@ This feature will allow you to customise to your own preferences, what triggers 
 
 - Select the token on the canvas you want to run the Wild Magic Surge for
 - Click your macro with the token still selected
-- The module will trigger a Wild Magic Surge on that actor
+- The module will trigger a Wild Magic Surge on that actor if a roll on 1d20 is less than 3
 
 ``` js
 
-Hooks.callAll(`wild-magic-surge-5e.manualTriggerWMS`, actor);
+// Create new roll object
+let roll = new Roll("1d20");
+
+// Roll the dice
+await roll.evaluate({async: false});
+
+// If total is less than 3 (i.e. less than 10%)
+if (roll.total < 3) {
+  // Trigger a wild magic surge passing the selected actor and roll
+  Hooks.callAll(`wild-magic-surge-5e.manualTriggerWMS`, actor, roll);
+}
+
 
 ```
 

--- a/scripts/macros/custom-roll-check.js
+++ b/scripts/macros/custom-roll-check.js
@@ -1,0 +1,11 @@
+// Create new roll object
+let roll = new Roll("1d20");
+
+// Roll the dice
+await roll.evaluate({async: false});
+
+// If total is less than 3 (i.e. less than 10%)
+if (roll.total < 3) {
+  // Trigger a wild magic surge passing the selected actor and roll
+  Hooks.callAll(`wild-magic-surge-5e.manualTriggerWMS`, actor, roll);
+}

--- a/scripts/module.ts
+++ b/scripts/module.ts
@@ -20,12 +20,14 @@ Hooks.on("init", function () {
 
   Hooks.on(
     "wild-magic-surge-5e.manualTriggerWMS",
-    async function (actor: Actor) {
-      const wildMagicSurgeCheck = new MagicSurgeCheck(
-        actor,
-        getTokenIdByActorId(actor.id)
-      );
-      wildMagicSurgeCheck.SurgeWildMagic(true, { result: 1 });
+    async function (actor: Actor, roll: Roll) {
+      if (roll && actor) {
+        const wildMagicSurgeCheck = new MagicSurgeCheck(
+          actor,
+          getTokenIdByActorId(actor.id)
+        );
+        wildMagicSurgeCheck.SurgeWildMagic(true, roll);
+      }
     }
   );
 

--- a/scripts/module.ts
+++ b/scripts/module.ts
@@ -19,6 +19,17 @@ Hooks.on("init", function () {
   );
 
   Hooks.on(
+    "wild-magic-surge-5e.manualTriggerWMS",
+    async function (actor: Actor) {
+      const wildMagicSurgeCheck = new MagicSurgeCheck(
+        actor,
+        getTokenIdByActorId(actor.id)
+      );
+      wildMagicSurgeCheck.SurgeWildMagic(true, { result: 1 });
+    }
+  );
+
+  Hooks.on(
     "renderChatMessage",
     async function (app: FormApplication, html: object) {
       const rollTableButton = html.find(".roll-table-wms");
@@ -34,7 +45,7 @@ Hooks.on("init", function () {
   );
 });
 
-function getTokenIdByActorId(actorId: string) {
+function getTokenIdByActorId(actorId: string): string | undefined {
   return canvas.tokens?.placeables?.find((f) => f.actor?.id === actorId)?.id;
 }
 


### PR DESCRIPTION
# Description

Add manual trigger hook for use in Macros.

e.g. calling the following in your Macro will trigger a surge.

`Hooks.callAll(`wild-magic-surge-5e.manualTriggerWMS`, actor);`

Fixes #520

To test and release Friday

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update