### PR TITLE
Adds new Hooks to manually manipulate roll state

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -87,7 +87,9 @@ In your macro, use the following code replacing the `Owr50jt6HyYru2e1` with the 
 
 `Hooks.callAll("wild-magic-surge-5e.Reset", "Owr50jt6HyYru2e1");`
 
-## wild-magic-surge-5e.ResetIncrementalCheck
+## Incremental Check Hooks
+
+### wild-magic-surge-5e.ResetIncrementalCheck
 
 This hook allows you to tell the module to reset the incremental count to 1. Handy for when you want to add homebrew rules like resetting after a long rest.
 
@@ -102,7 +104,27 @@ In your macro, use the following code replacing the `Owr50jt6HyYru2e1` with the 
 
 `Hooks.callAll("wild-magic-surge-5e.ResetIncrementalCheck", "Owr50jt6HyYru2e1");`
 
-## wild-magic-surge-5e.ResetDieDescending
+
+## wild-magic-surge-5e.SetIncrementalCheck
+
+This hook allows you to specify which die to use for the incremental count. Handy for when you want to add homebrew rules like increasing or decreasing manually based on a story element or other event.
+
+To get the actor ID
+
+* select the token you want on the map
+* Press F12
+* In the Console paste `canvas.tokens.controlled[0].data.actorId`
+* This is your actorId
+
+In your macro, use the following code replacing the `Owr50jt6HyYru2e1` with the above actorId
+
+The last argument is a value 1-20 which sets what the target roll to trigger should be.
+
+`Hooks.callAll("wild-magic-surge-5e.SetIncrementalCheck", "Owr50jt6HyYru2e1", 1);`
+
+## Die Descending Hooks
+
+### wild-magic-surge-5e.ResetDieDescending
 
 This hook allows you to tell the module to reset the Die Descending count. Handy for when you want to add homebrew rules like resetting after a long rest.
 
@@ -117,7 +139,7 @@ In your macro, use the following code replacing the `Owr50jt6HyYru2e1` with the 
 
 `Hooks.callAll("wild-magic-surge-5e.ResetDieDescending", "Owr50jt6HyYru2e1");`
 
-## wild-magic-surge-5e.SetDieDescending
+### wild-magic-surge-5e.SetDieDescending
 
 This hook allows you to specify which die to use for the Die Descending count. Handy for when you want to add homebrew rules like increasing or decreasing manually based on a story element or other event.
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -116,3 +116,27 @@ To get the actor ID
 In your macro, use the following code replacing the `Owr50jt6HyYru2e1` with the above actorId
 
 `Hooks.callAll("wild-magic-surge-5e.ResetDieDescending", "Owr50jt6HyYru2e1");`
+
+## wild-magic-surge-5e.SetDieDescending
+
+This hook allows you to specify which die to use for the Die Descending count. Handy for when you want to add homebrew rules like increasing or decreasing manually based on a story element or other event.
+
+To get the actor ID
+
+* select the token you want on the map
+* Press F12
+* In the Console paste `canvas.tokens.controlled[0].data.actorId`
+* This is your actorId
+
+In your macro, use the following code replacing the `Owr50jt6HyYru2e1` with the above actorId
+
+The 1-6 value in the example specified which dice to switch to.
+
+* 1 = D20
+* 2 = D12
+* 3 = D10
+* 4 = D8
+* 5 = D6
+* 6 = D4
+
+`Hooks.callAll("wild-magic-surge-5e.SetDieDescending", "Owr50jt6HyYru2e1", 1);`

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -72,6 +72,21 @@ Runs when you set the module to auto roll a check for you. The result of the rol
 }
 ```
 
+## wild-magic-surge-5e.Reset
+
+This hook allows you to tell the module to reset the incremental and descending count. Handy for when you want to add homebrew rules like resetting after a long rest.
+
+To get the actor ID
+
+* select the token you want on the map
+* Press F12
+* In the Console paste `canvas.tokens.controlled[0].data.actorId`
+* This is your actorId
+
+In your macro, use the following code replacing the `Owr50jt6HyYru2e1` with the above actorId
+
+`Hooks.callAll("wild-magic-surge-5e.Reset", "Owr50jt6HyYru2e1");`
+
 ## wild-magic-surge-5e.ResetIncrementalCheck
 
 This hook allows you to tell the module to reset the incremental count to 1. Handy for when you want to add homebrew rules like resetting after a long rest.
@@ -86,3 +101,18 @@ To get the actor ID
 In your macro, use the following code replacing the `Owr50jt6HyYru2e1` with the above actorId
 
 `Hooks.callAll("wild-magic-surge-5e.ResetIncrementalCheck", "Owr50jt6HyYru2e1");`
+
+## wild-magic-surge-5e.ResetDieDescending
+
+This hook allows you to tell the module to reset the Die Descending count. Handy for when you want to add homebrew rules like resetting after a long rest.
+
+To get the actor ID
+
+* select the token you want on the map
+* Press F12
+* In the Console paste `canvas.tokens.controlled[0].data.actorId`
+* This is your actorId
+
+In your macro, use the following code replacing the `Owr50jt6HyYru2e1` with the above actorId
+
+`Hooks.callAll("wild-magic-surge-5e.ResetDieDescending", "Owr50jt6HyYru2e1");`

--- a/scripts/module.ts
+++ b/scripts/module.ts
@@ -170,6 +170,4 @@ Hooks.once("ready", async function () {
       _resetChecks(actorId);
     },
   );
-
-
 });

--- a/scripts/module.ts
+++ b/scripts/module.ts
@@ -181,4 +181,15 @@ Hooks.once("ready", async function () {
       DieDescending.OverrideResource(actor, resourceNumber);
     },
   );
+
+    Hooks.on(
+    "wild-magic-surge-5e.SetIncrementalCheck",
+    async function (actorId: string, resourceNumber: number) {
+      const actor = game.actors.get(actorId);
+      if (!actor) {
+        return false;
+      }
+      IncrementalCheck.OverrideResource(actor, resourceNumber);
+    },
+  );
 });

--- a/scripts/module.ts
+++ b/scripts/module.ts
@@ -157,17 +157,28 @@ Hooks.once("ready", async function () {
     },
   );
 
-    Hooks.on(
+  Hooks.on(
     "wild-magic-surge-5e.ResetDieDescending",
     async function (actorId: string) {
       _resetChecks(actorId);
     },
   );
 
-    Hooks.on(
+  Hooks.on(
     "wild-magic-surge-5e.ResetIncrementalCheck",
     async function (actorId: string) {
       _resetChecks(actorId);
+    },
+  );
+
+  Hooks.on(
+    "wild-magic-surge-5e.SetDieDescending",
+    async function (actorId: string, resourceNumber: number) {
+      const actor = game.actors.get(actorId);
+      if (!actor) {
+        return false;
+      }
+      DieDescending.OverrideResource(actor, resourceNumber);
     },
   );
 });

--- a/scripts/utils/DieDescending.ts
+++ b/scripts/utils/DieDescending.ts
@@ -84,4 +84,13 @@ export default class DieDescending extends Resource {
 
     return false;
   }
+
+  static async OverrideResource(actor: Actor, resourceNumber: number): Promise<void> {
+    await this.SetResource(actor, {
+        max: 6,
+        value: resourceNumber,
+      });
+      const resourceValue = await this.GetResource(actor);
+      await this._callChanged(resourceValue);
+  }
 }

--- a/scripts/utils/IncrementalCheck.ts
+++ b/scripts/utils/IncrementalCheck.ts
@@ -58,4 +58,13 @@ export default class IncrementalCheck extends Resource {
 
     return false;
   }
+
+  static async OverrideResource(actor: Actor, resourceNumber: number): Promise<void> {
+    await this.SetResource(actor, {
+        max: 20,
+        value: resourceNumber,
+      });
+      const resourceValue = await this.GetResource(actor);
+      await this._callChanged(resourceValue.value);
+  }
 }


### PR DESCRIPTION
# Description

This change creates 4 new hooks to allow users to override manually via macros the Incremental and Die Descending values. It also allows users to reset the values as if a surge has happened.

* `wild-magic-surge-5e.ResetDieDescending`
* `wild-magic-surge-5e.Reset`
* `wild-magic-surge-5e.SetDieDescending`
* `wild-magic-surge-5e.SetIncrementalCheck`

Fixes #890 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update