### PR TITLE
Add Upcast Spell Settings

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -15,7 +15,7 @@
 
   "WildMagicSurge5E.opt_whisper_gm_name": "Whisper Wild Magic Surge Roll Check to GM",
   "WildMagicSurge5E.opt_whisper_gm_hint": "The surge check roll message is only sent to the GM instead of all players.",
-  
+
   "WildMagicSurge5E.opt_whisper_gm_roll_chat_name": "Whisper Auto Roll Table result to GM",
   "WildMagicSurge5E.opt_whisper_gm_roll_chat_hint": "Auto Roll Table results are only sent to the GM instead of all players.",
 
@@ -39,7 +39,7 @@
 
   "WildMagicSurge5E.opt_auto_d20_msg_no_surge_name": "Surge Chat Message Fail",
   "WildMagicSurge5E.opt_auto_d20_msg_no_surge_hint": "On a failed auto Wild Magic Surge roll, show this message.",
-  
+
   "WildMagicSurge5E.opt_auto_d20_msg_enabled_name": "Show Message",
   "WildMagicSurge5E.opt_auto_d20_msg_enabled_hint": "Optionally enable this message to show.",
 
@@ -96,7 +96,7 @@
 
   "WildMagicSurge5E.opt_cantrip_surge_enabled_name": "Roll for surge on Cantrips",
   "WildMagicSurge5E.opt_cantrip_surge_enabled_hint": "Standard rules are 1st Level and higher to trigger a surge. This also enables it for Cantrips.",
-  
+
   "WildMagicSurge5E.opt_minimum_spell_level_trigger_name": "Set minimum Spell Level to trigger Surge",
   "WildMagicSurge5E.opt_minimum_spell_level_trigger_hint": "Set a custom minimum level to trigger a Wild Magic Surge. For example 3 would only trigger on spells cast at level 3 or higher.",
 
@@ -120,5 +120,16 @@
   "WildMagicSurge5E.settings_panel_incremental": "Incremental Check Variant",
   "WildMagicSurge5E.settings_panel_chat_message": "Chat Message Options",
   "WildMagicSurge5E.configure": "Configure",
-  "WildMagicSurge5E.settings_panel_information": "Wild Magic Surge 5e Information"
+  "WildMagicSurge5E.settings_panel_information": "Wild Magic Surge 5e Information",
+  "WildMagicSurge5E.settings_panel_upcast": "Upcast Spell Options",
+
+  "WildMagicSurge5E.opt_upcast_wms_trigger_base_name": "Wild Magic Surge Rolls — Base-Level Spells",
+  "WildMagicSurge5E.opt_upcast_wms_trigger_base_hint": "Trigger a Wild Magic Surge Roll when a spell is cast at its normal level. Requires \"Automate Wild Magic Surge\" to be enabled.",
+  "WildMagicSurge5E.opt_upcast_wms_trigger_upcast_name": "Wild Magic Surge Rolls — Upcast Spells",
+  "WildMagicSurge5E.opt_upcast_wms_trigger_upcast_hint": "Trigger a Wild Magic Surge Roll when a spell is cast using a higher-level spell slot. Requires \"Automate Wild Magic Surge\" to be enabled.",
+
+  "WildMagicSurge5E.opt_upcast_toc_trigger_base_name": "Tides of Chaos Surges — Base-Level Spells",
+  "WildMagicSurge5E.opt_upcast_toc_trigger_base_hint": "Trigger a Tides of Chaos Wild Magic Surge when a spell is cast at its normal level. Requires the Auto Surge After Tides of Chaos to be enabled.",
+  "WildMagicSurge5E.opt_upcast_toc_trigger_upcast_name": "Tides of Chaos Surges — Upcast Spells",
+  "WildMagicSurge5E.opt_upcast_toc_trigger_upcast_hint": "Trigger a Tides of Chaos Wild Magic Surge when a spell is cast using a higher-level spell slot. Requires the Auto Surge After Tides of Chaos to be enabled."
 }

--- a/scripts/MagicSurgeCheck.test.ts
+++ b/scripts/MagicSurgeCheck.test.ts
@@ -15,34 +15,34 @@ import TriggerMacro from "./TriggerMacro";
 
 const mockSpellParserIsPathOfWildMagicFeat = jest.spyOn(
   SpellParser,
-  "IsPathOfWildMagicFeat"
+  "IsPathOfWildMagicFeat",
 );
 const mockSpellParserSpellLevel = jest.spyOn(SpellParser, "SpellLevel");
 const mockSpellParserIsRage = jest.spyOn(SpellParser, "IsRage");
 const mockSpellParserIsSpell = jest.spyOn(SpellParser, "IsSpell");
 const mockSpellParserIsSorcererSpell = jest.spyOn(
   SpellParser,
-  "IsSorcererSpell"
+  "IsSorcererSpell",
 );
 const mockSpellParserIsWildMagicFeat = jest.spyOn(
   SpellParser,
-  "IsWildMagicFeat"
+  "IsWildMagicFeat",
 );
 
 const mockSurgeDetailsValid = jest.spyOn(
   SurgeDetails.prototype,
   "valid",
-  "get"
+  "get",
 );
 const mockSurgeDetailsHasPathOfWildMagicFeat = jest.spyOn(
   SurgeDetails.prototype,
   "hasPathOfWildMagicFeat",
-  "get"
+  "get",
 );
 const mockSurgeDetailsSpellLevel = jest.spyOn(
   SurgeDetails.prototype,
   "spellLevel",
-  "get"
+  "get",
 );
 
 const mockDieDescendingCheck = jest.fn();
@@ -130,7 +130,9 @@ describe("MagicSurgeCheck", () => {
             get: jest.fn().mockReturnValue(true),
           },
         };
-        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4");
+        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4", {
+          scaling: 0,
+        });
 
         mockSurgeDetailsValid.mockReturnValue(false);
 
@@ -167,7 +169,9 @@ describe("MagicSurgeCheck", () => {
             get: jest.fn().mockReturnValue(true),
           },
         };
-        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4");
+        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4", {
+          scaling: 0,
+        });
 
         mockSurgeDetailsValid.mockReturnValue(true);
         mockSurgeDetailsHasPathOfWildMagicFeat.mockReturnValue(false);
@@ -206,7 +210,9 @@ describe("MagicSurgeCheck", () => {
           },
         };
 
-        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4");
+        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4", {
+          scaling: 0,
+        });
 
         mockSurgeDetailsValid.mockReturnValue(true);
         mockSurgeDetailsHasPathOfWildMagicFeat.mockReturnValue(false);
@@ -245,7 +251,9 @@ describe("MagicSurgeCheck", () => {
           },
         };
 
-        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4");
+        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4", {
+          scaling: 0,
+        });
 
         mockSurgeDetailsValid.mockReturnValue(true);
         mockSurgeDetailsHasPathOfWildMagicFeat.mockReturnValue(true);
@@ -258,7 +266,10 @@ describe("MagicSurgeCheck", () => {
 
         expect(mockSpellParserIsPathOfWildMagicFeat).toHaveBeenCalledTimes(1);
 
-        expect(mockRollTableMagicSurgeCheck).toHaveBeenCalledWith("POWM", actor);
+        expect(mockRollTableMagicSurgeCheck).toHaveBeenCalledWith(
+          "POWM",
+          actor,
+        );
 
         expect(magicSurgeCheck.AutoSurgeCheck).not.toHaveBeenCalled();
       });
@@ -287,13 +298,15 @@ describe("MagicSurgeCheck", () => {
           },
         };
 
-        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4");
+        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4", {
+          scaling: 0,
+        });
       });
 
       it("It calls Roll with 1D20", async () => {
         await magicSurgeCheck.WildMagicSurgeRollCheck();
 
-        expect((global as any).Roll).toHaveBeenCalled());
+        expect((global as any).Roll).toHaveBeenCalled();
       });
     });
 
@@ -317,15 +330,17 @@ describe("MagicSurgeCheck", () => {
               .mockReturnValueOnce("1D20"),
           },
         };
-        
-      (global as any).ui = {
-        notifications: {
-          warn: jest.fn(),
-          info: jest.fn(),
-        }
-      };
 
-        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4");
+        (global as any).ui = {
+          notifications: {
+            warn: jest.fn(),
+            info: jest.fn(),
+          },
+        };
+
+        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4", {
+          scaling: 0,
+        });
       });
 
       it("It calls Roll with 1D20", async () => {
@@ -357,7 +372,9 @@ describe("MagicSurgeCheck", () => {
         };
 
         actor.getFlag = jest.fn().mockReturnValue({ value: "1D20" });
-        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4");
+        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4", {
+          scaling: 0,
+        });
       });
 
       it("It calls Roll with 1D20", async () => {
@@ -391,7 +408,9 @@ describe("MagicSurgeCheck", () => {
         actor.getFlag = jest.fn().mockReturnValue(undefined);
 
         actor.setFlag = jest.fn();
-        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4");
+        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4", {
+          scaling: 0,
+        });
       });
 
       it("It calls Roll with 1D20", async () => {
@@ -426,7 +445,9 @@ describe("MagicSurgeCheck", () => {
             },
           ],
         };
-        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4");
+        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4", {
+          scaling: 0,
+        });
       });
       test("roll of 2 EQ 2", async () => {
         const result = magicSurgeCheck.DefaultMagicSurgeRollResult(2, "EQ");
@@ -463,7 +484,9 @@ describe("MagicSurgeCheck", () => {
     describe("has 2 values in the result check", () => {
       let magicSurgeCheck: MagicSurgeCheck;
       beforeAll(() => {
-        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4");
+        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4", {
+          scaling: 0,
+        });
         (global as any).game = {
           modules: {
             get: () => {
@@ -543,11 +566,13 @@ describe("MagicSurgeCheck", () => {
             get: jest.fn().mockReturnValue(true),
           },
         };
-        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4");
+        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4", {
+          scaling: 0,
+        });
 
         defaultSurgeTidesOfChaosSpy = jest.spyOn(
           magicSurgeCheck,
-          "SurgeTidesOfChaos"
+          "SurgeTidesOfChaos",
         );
 
         jest.spyOn(magicSurgeCheck, "SurgeWildMagic").mockReturnValue(true);
@@ -607,12 +632,14 @@ describe("MagicSurgeCheck", () => {
             }),
           },
         };
-        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4");
+        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4", {
+          scaling: 0,
+        });
         mockTidesOfChaosIsTidesOfChaosUsed.mockReturnValue(false);
 
         defaultMagicSurgeRollResultSpy = jest.spyOn(
           magicSurgeCheck,
-          "DefaultMagicSurgeRollResult"
+          "DefaultMagicSurgeRollResult",
         );
 
         jest
@@ -768,12 +795,14 @@ describe("MagicSurgeCheck", () => {
             }),
           },
         };
-        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4");
+        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4", {
+          scaling: 0,
+        });
         mockTidesOfChaosIsTidesOfChaosUsed.mockReturnValue(false);
 
         defaultMagicSurgeRollResultSpy = jest.spyOn(
           magicSurgeCheck,
-          "DefaultMagicSurgeRollResult"
+          "DefaultMagicSurgeRollResult",
         );
 
         jest
@@ -810,7 +839,9 @@ describe("MagicSurgeCheck", () => {
             },
           },
         };
-        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4");
+        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4", {
+          scaling: 0,
+        });
         mockRollTableMagicSurgeCheck.mockResolvedValueOnce("test result");
       });
 
@@ -850,7 +881,9 @@ describe("MagicSurgeCheck", () => {
             },
           },
         };
-        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4");
+        magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4", {
+          scaling: 0,
+        });
       });
 
       it("It runs the correct functions", async () => {
@@ -873,7 +906,9 @@ describe("MagicSurgeCheck", () => {
     let magicSurgeCheck: MagicSurgeCheck;
 
     beforeEach(() => {
-      magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4");
+      magicSurgeCheck = new MagicSurgeCheck(actor, "rMyoELkOwFNPGEK4", {
+        scaling: 0,
+      });
     });
 
     it("It splits one value into an array", async () => {

--- a/scripts/MagicSurgeCheck.ts
+++ b/scripts/MagicSurgeCheck.ts
@@ -10,6 +10,8 @@ import CallHooks from "./utils/CallHooks";
 import SurgeDetails from "./utils/SurgeDetails";
 import Logger from "./Logger";
 import TriggerMacro from "./TriggerMacro";
+import { UsageConfig } from "foundry-extensions";
+import SpellParser from "./utils/SpellParser";
 
 /**
  * Main entry point for Wild Magic Surge Checks
@@ -21,9 +23,15 @@ import TriggerMacro from "./TriggerMacro";
 class MagicSurgeCheck {
   _actor: Actor;
   _tokenId: string | undefined;
-  constructor(actor: Actor, tokenId: string | undefined) {
+  _usageConfig: UsageConfig;
+  constructor(
+    actor: Actor,
+    tokenId: string | undefined,
+    usageConfig: UsageConfig,
+  ) {
     this._actor = actor;
     this._tokenId = tokenId;
+    this._usageConfig = usageConfig;
   }
 
   async _rollPlayerTrigger(
@@ -207,6 +215,7 @@ class MagicSurgeCheck {
     let roll: Roll | undefined;
 
     let isAutoSurge = false;
+    const isUpcastSpell = SpellParser.IsUpcastSpell(this._usageConfig);
     if (
       game.settings.get(
         `${WMSCONST.MODULE_ID}`,
@@ -214,12 +223,31 @@ class MagicSurgeCheck {
       )
     ) {
       if (await TidesOfChaos.IsTidesOfChaosUsed(this._actor)) {
-        isAutoSurge = true;
-        this.SurgeTidesOfChaos();
+        if (
+          game.settings.get(
+            WMSCONST.MODULE_ID,
+            isUpcastSpell
+              ? WMSCONST.OPT_UPCAST_TOC_TRIGGER_UPCAST
+              : WMSCONST.OPT_UPCAST_TOC_TRIGGER_BASE,
+          )
+        ) {
+          isAutoSurge = true;
+          this.SurgeTidesOfChaos();
+        }
       }
     }
 
     if (!isAutoSurge) {
+      if (
+        !game.settings.get(
+          WMSCONST.MODULE_ID,
+          isUpcastSpell
+            ? WMSCONST.OPT_UPCAST_WMS_TRIGGER_UPCAST
+            : WMSCONST.OPT_UPCAST_WMS_TRIGGER_BASE,
+        )
+      ) {
+        return;
+      }
       roll = await this.WildMagicSurgeRollCheck(spellLevel);
       if (!roll) return;
       const rollTotal = roll.total ?? 1;

--- a/scripts/ModuleSettings.ts
+++ b/scripts/ModuleSettings.ts
@@ -1,4 +1,5 @@
 import { WMSCONST } from "./WMSCONST";
+import { UpcastSettingsPanel } from "./panels/UpcastSettingsPanel";
 import {
   ChatSettingsPanel,
   IncrementalSettingsPanel,
@@ -200,6 +201,15 @@ class ModuleSettings {
       restricted: true,
     });
 
+    game.settings.registerMenu(`${WMSCONST.MODULE_ID}`, `UpcastSettingsPanel`, {
+      name: game.i18n.format("WildMagicSurge5E.settings_panel_upcast"),
+      label: game.i18n.format("WildMagicSurge5E.configure"),
+      icon: "fas fa-cog",
+      scope: "world",
+      type: UpcastSettingsPanel,
+      restricted: true,
+    });
+
     game.settings.register(
       `${WMSCONST.MODULE_ID}`,
       `${WMSCONST.OPT_INCREMENTAL_CHECK_TO_CHAT}`,
@@ -239,6 +249,76 @@ class ModuleSettings {
         ),
         hint: game.i18n.format(
           "WildMagicSurge5E.opt_auto_d20_msg_enabled_hint",
+        ),
+        scope: "world",
+        config: false,
+        default: true,
+        type: Boolean,
+      },
+    );
+
+    game.settings.register(
+      WMSCONST.MODULE_ID,
+      WMSCONST.OPT_UPCAST_WMS_TRIGGER_BASE,
+      {
+        name: game.i18n.format(
+          "WildMagicSurge5E.opt_upcast_wms_trigger_base_name",
+        ),
+        hint: game.i18n.format(
+          "WildMagicSurge5E.opt_upcast_wms_trigger_base_hint",
+        ),
+        scope: "world",
+        config: false,
+        default: true,
+        type: Boolean,
+      },
+    );
+
+    game.settings.register(
+      WMSCONST.MODULE_ID,
+      WMSCONST.OPT_UPCAST_WMS_TRIGGER_UPCAST,
+      {
+        name: game.i18n.format(
+          "WildMagicSurge5E.opt_upcast_wms_trigger_upcast_name",
+        ),
+        hint: game.i18n.format(
+          "WildMagicSurge5E.opt_upcast_wms_trigger_upcast_hint",
+        ),
+        scope: "world",
+        config: false,
+        default: true,
+        type: Boolean,
+      },
+    );
+
+    // TOC
+
+    game.settings.register(
+      WMSCONST.MODULE_ID,
+      WMSCONST.OPT_UPCAST_TOC_TRIGGER_BASE,
+      {
+        name: game.i18n.format(
+          "WildMagicSurge5E.opt_upcast_toc_trigger_base_name",
+        ),
+        hint: game.i18n.format(
+          "WildMagicSurge5E.opt_upcast_toc_trigger_base_hint",
+        ),
+        scope: "world",
+        config: false,
+        default: true,
+        type: Boolean,
+      },
+    );
+
+    game.settings.register(
+      WMSCONST.MODULE_ID,
+      WMSCONST.OPT_UPCAST_TOC_TRIGGER_UPCAST,
+      {
+        name: game.i18n.format(
+          "WildMagicSurge5E.opt_upcast_toc_trigger_upcast_name",
+        ),
+        hint: game.i18n.format(
+          "WildMagicSurge5E.opt_upcast_toc_trigger_upcast_hint",
         ),
         scope: "world",
         config: false,

--- a/scripts/WMSCONST.ts
+++ b/scripts/WMSCONST.ts
@@ -51,6 +51,12 @@ export const WMSCONST = {
   OPT_TSL_LVL9: "OPT_TSL_LVL9",
   OPT_TSL_LVL10: "OPT_TSL_LVL10",
 
+  OPT_UPCAST_WMS_TRIGGER_BASE: "wmsTriggerBaseLevel",
+  OPT_UPCAST_WMS_TRIGGER_UPCAST: "wmsTriggerUpcast",
+
+  OPT_UPCAST_TOC_TRIGGER_BASE: "tocTriggerBaseLevel",
+  OPT_UPCAST_TOC_TRIGGER_UPCAST: "tocTriggerUpcast",
+
   CHAT_TYPE: {
     DEFAULT: "DEFAULT",
     ROLL: "ROLL",

--- a/scripts/module.ts
+++ b/scripts/module.ts
@@ -8,6 +8,7 @@ import { RoundData } from "@league-of-foundry-developers/foundry-vtt-types/src/f
 import Logger from "./Logger";
 import RollTableMagicSurge from "./RollTableMagicSurge";
 import DieDescending from "./utils/DieDescending";
+import { UsageConfig } from "foundry-extensions";
 
 Hooks.on("init", function () {
   Logger.log(`Registering ${WMSCONST.MODULE_NAME} Settings.`, "module.init");
@@ -32,18 +33,15 @@ Hooks.on("init", function () {
     },
   );
 
-  Hooks.on(
-    "wild-magic-surge-5e.reset",
-    async function (actor: Actor) {
-      if (actor) {
-        const wildMagicSurgeCheck = new MagicSurgeCheck(
-          actor,
-          getTokenIdByActorId(actor.id),
-        );
-        wildMagicSurgeCheck.SurgeWildMagic(true, roll);
-      }
-    },
-  );
+  Hooks.on("wild-magic-surge-5e.reset", async function (actor: Actor) {
+    if (actor) {
+      const wildMagicSurgeCheck = new MagicSurgeCheck(
+        actor,
+        getTokenIdByActorId(actor.id),
+      );
+      wildMagicSurgeCheck.SurgeWildMagic(true, roll);
+    }
+  });
 
   Hooks.on(
     "renderChatMessage",
@@ -115,29 +113,36 @@ Hooks.once("ready", async function () {
     );
   }
 
-  Hooks.on("dnd5e.postUseActivity", (activity: Item) => {
-    const item = activity.item;
+  Hooks.on(
+    "dnd5e.postUseActivity",
+    (activity: Item, usageConfig: UsageConfig) => {
+      const item = activity.item;
 
-    // Only fire when a spell slot is actually consumed
-    if (!activity.consumption?.spellSlot) return;
+      // Only fire when a spell slot is actually consumed
+      if (!activity.consumption?.spellSlot) return;
 
-    if (item.actor) {
-      const tokenId = getTokenIdByActorId(item?.actor.id);
-      if (game.user?.isGM) {
-        const magicSurgeCheck = new MagicSurgeCheck(item.actor, tokenId);
-        magicSurgeCheck.CheckItem(item);
-      } else {
-        game.socket?.emit("module.wild-magic-surge-5e", {
-          event: "SurgeCheck",
-          data: {
-            actorId: item?.actor.id,
-            tokenId: tokenId,
-            item: item,
-          },
-        });
+      if (item.actor) {
+        const tokenId = getTokenIdByActorId(item?.actor.id);
+        if (game.user?.isGM) {
+          const magicSurgeCheck = new MagicSurgeCheck(
+            item.actor,
+            tokenId,
+            usageConfig,
+          );
+          magicSurgeCheck.CheckItem(item);
+        } else {
+          game.socket?.emit("module.wild-magic-surge-5e", {
+            event: "SurgeCheck",
+            data: {
+              actorId: item?.actor.id,
+              tokenId: tokenId,
+              item: item,
+            },
+          });
+        }
       }
-    }
-  });
+    },
+  );
 
   if (
     game.settings.get(
@@ -145,14 +150,20 @@ Hooks.once("ready", async function () {
       `${WMSCONST.OPT_SHOW_WMS_DEBUG_OPTION}`,
     )
   ) {
-    Hooks.on("getHeaderControlsActorSheetV2", (app: CharacterActorSheet, controls: Array<any>) => {
-      controls.push({
-        label: "WMS",
-        icon: "fas fa-wrench",
-        onClick: () => new ActorHelperPanel({ document: app.document }).render({ force: true }),
-        button: true,
-      });
-    });
+    Hooks.on(
+      "getHeaderControlsActorSheetV2",
+      (app: CharacterActorSheet, controls: Array<any>) => {
+        controls.push({
+          label: "WMS",
+          icon: "fas fa-wrench",
+          onClick: () =>
+            new ActorHelperPanel({ document: app.document }).render({
+              force: true,
+            }),
+          button: true,
+        });
+      },
+    );
   }
 
   if (game.user?.isGM) {
@@ -171,12 +182,9 @@ Hooks.once("ready", async function () {
     });
   }
 
-  Hooks.on(
-    "wild-magic-surge-5e.Reset",
-    async function (actorId: string) {
-      _resetChecks(actorId);
-    },
-  );
+  Hooks.on("wild-magic-surge-5e.Reset", async function (actorId: string) {
+    _resetChecks(actorId);
+  });
 
   Hooks.on(
     "wild-magic-surge-5e.ResetDieDescending",

--- a/scripts/panels/UpcastSettingsPanel.ts
+++ b/scripts/panels/UpcastSettingsPanel.ts
@@ -1,0 +1,37 @@
+import { WMSCONST } from "../WMSCONST";
+import { SettingsList, UpdateObject } from "./Helpers";
+
+export class UpcastSettingsPanel extends FormApplication {
+  static get defaultOptions() {
+    return mergeObject(super.defaultOptions, {
+      title: game.i18n.format("WildMagicSurge5E.settings_panel_upcast"),
+      template: "modules/wild-magic-surge-5e/templates/settings.html",
+      id: `${WMSCONST.MODULE_FLAG_NAME}-upcast-settings`,
+      width: 520,
+      height: "500",
+      closeOnSubmit: true,
+    });
+  }
+
+  settingsList(settings: any) {
+    return SettingsList(settings);
+  }
+
+  getData() {
+    const settings = [
+      WMSCONST.OPT_UPCAST_WMS_TRIGGER_BASE,
+      WMSCONST.OPT_UPCAST_WMS_TRIGGER_UPCAST,
+      WMSCONST.OPT_UPCAST_TOC_TRIGGER_BASE,
+      WMSCONST.OPT_UPCAST_TOC_TRIGGER_UPCAST,
+    ];
+
+    return {
+      modules: this.settingsList(settings),
+    };
+  }
+
+  // @ts-expect-error TS(2416): Property '_updateObject' in type 'UpcastSettingsPanel' is ... Remove this comment to see the full error message
+  _updateObject(_event: any, formData: any) {
+    UpdateObject(formData);
+  }
+}

--- a/scripts/types/foundry-extensions.d.ts
+++ b/scripts/types/foundry-extensions.d.ts
@@ -1,0 +1,3 @@
+export interface UsageConfig {
+  scaling: number;
+}

--- a/scripts/utils/SpellParser.test.ts
+++ b/scripts/utils/SpellParser.test.ts
@@ -1,7 +1,22 @@
 import SpellParser from "./SpellParser";
 import { actor } from "../../MockData/actor";
 import { actorNoWildMagic } from "../../MockData/actorNoWildMagic";
-import { cantrip, eighthLevel, fifthLevel, firstLevel, fourthLevel, melee, ninthLevel, rage, secondLevel, seventhLevel, sixthLevel, sorcererSpecificSpell, tenthLevel, thirdLevel } from "../../MockData/items";
+import {
+  cantrip,
+  eighthLevel,
+  fifthLevel,
+  firstLevel,
+  fourthLevel,
+  melee,
+  ninthLevel,
+  rage,
+  secondLevel,
+  seventhLevel,
+  sixthLevel,
+  sorcererSpecificSpell,
+  tenthLevel,
+  thirdLevel,
+} from "../../MockData/items";
 import "../../__mocks__/index";
 
 describe("SpellParser", () => {
@@ -169,6 +184,25 @@ describe("SpellParser", () => {
     });
   });
 
+  describe("IsUpcastSpell", () => {
+    it("returns true when scaling > 0", () => {
+      expect(SpellParser.IsUpcastSpell({ scaling: 1 } as any)).toBe(true);
+      expect(SpellParser.IsUpcastSpell({ scaling: 2 } as any)).toBe(true);
+    });
+
+    it("returns false when scaling is 0", () => {
+      expect(SpellParser.IsUpcastSpell({ scaling: 0 } as any)).toBe(false);
+    });
+
+    it("returns false when scaling is undefined", () => {
+      expect(SpellParser.IsUpcastSpell({} as any)).toBe(false);
+    });
+
+    it("returns false when usageConfig is undefined", () => {
+      expect(SpellParser.IsUpcastSpell(undefined as any)).toBe(false);
+    });
+  });
+
   describe("SpellDetails", () => {
     describe("Is set to level 3 or higher", () => {
       describe("it is a level 2 spell", () => {
@@ -177,14 +211,17 @@ describe("SpellParser", () => {
           jest.resetAllMocks();
           (global as any).game = {
             settings: {
-              get: jest.fn().mockReturnValueOnce("3").mockReturnValueOnce(false),
+              get: jest
+                .fn()
+                .mockReturnValueOnce("3")
+                .mockReturnValueOnce(false),
             },
           };
         });
 
         it("should be undefined", async () => {
           const result = SpellParser.SpellDetails(firstLevel);
-  
+
           expect(result).toBeUndefined();
         });
       });
@@ -202,7 +239,7 @@ describe("SpellParser", () => {
 
         it("should be 3rd Level", async () => {
           const result = SpellParser.SpellDetails(thirdLevel);
-  
+
           expect(result).toBe("3rd Level");
         });
       });
@@ -330,7 +367,10 @@ describe("SpellParser", () => {
       };
       (global as any).game = {
         settings: {
-          get: jest.fn().mockReturnValueOnce("\\(S\\)").mockReturnValueOnce(false),
+          get: jest
+            .fn()
+            .mockReturnValueOnce("\\(S\\)")
+            .mockReturnValueOnce(false),
         },
       };
     });
@@ -359,7 +399,10 @@ describe("SpellParser", () => {
       };
       (global as any).game = {
         settings: {
-          get: jest.fn().mockReturnValueOnce("\\(S\\)").mockReturnValueOnce(true),
+          get: jest
+            .fn()
+            .mockReturnValueOnce("\\(S\\)")
+            .mockReturnValueOnce(true),
         },
       };
     });

--- a/scripts/utils/SpellParser.ts
+++ b/scripts/utils/SpellParser.ts
@@ -1,3 +1,4 @@
+import { UsageConfig } from "foundry-extensions";
 import { WMSCONST } from "../WMSCONST";
 
 export default class SpellParser {
@@ -107,6 +108,15 @@ export default class SpellParser {
   static IsSpell(item: Item): boolean {
     const result = SpellParser.SpellDetails(item);
     return result !== undefined && item.type === "spell";
+  }
+
+  /**
+   * Checks if the spell was cast at a higher level
+   * @param usageConfig
+   * @returns {boolean}
+   */
+  static IsUpcastSpell(usageConfig: UsageConfig): boolean {
+    return (usageConfig?.scaling ?? 0) > 0;
   }
 
   /**

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -17,7 +17,7 @@
     {{/if}}
     {{#if this.isBoolean}}
     <div class="form-group">
-      <label>{{this.displayname}}</label>
+      <label style="flex-grow: 6;">{{this.displayname}}</label>
       <div class="form-fields">
         <input type="checkbox"
           name="{{this.module}}.{{this.key}}"


### PR DESCRIPTION
This started as small tweaks and ended up just adding in the feature I needed over the weekend, If you feel this is too niche of a feature for this module, I totally understand.

# Description

This PR introduces upcast-aware Wild Magic Surge / Tides of Chaos logic, adds a new settings panel, and threads spell cast scaling information through the system.

Adds a full configuration layer for separating behavior based on cast type:

New settings menu: “Upcast Spell Options”

<img width="523" height="302" alt="image" src="https://github.com/user-attachments/assets/25daa1ce-7d45-4a22-ac09-5fd15d81affb" />

Four new settings:

- Wild Magic Surge triggers:
  - Base-level spells
  - Upcast spells
- Tides of Chaos triggers:
  - Base-level spells
  - Upcast spells

<img width="517" height="497" alt="image" src="https://github.com/user-attachments/assets/4197c3d3-3157-4583-bc95-e00e1fea1f8e" />

Had to adjust the template slightly to give a bit more room for the title on boolean fields.

**dnd5e.postUseActivity** now passes usageConfig so that upcasting can be detected

- [ X ] New feature (non-breaking change which adds functionality)


